### PR TITLE
Handle EPIPE error when writing to STDIN

### DIFF
--- a/lib/sdtin-write.ts
+++ b/lib/sdtin-write.ts
@@ -7,14 +7,13 @@ import { ChildProcess } from "child_process";
  */
 export function writeToStdin(proc: ChildProcess, stdin: string): void {
     if (stdin) {
-        try {
-            proc.stdin.write(stdin + '\r\n');
-            proc.stdin.end();
-        }
-        catch (err) {
-            // Maybe the stream was already closed for us to write.
-            // To fix issue #2
+        proc.stdin.write(stdin + '\r\n', err => {
+            if(!err)
+                proc.stdin.end();
+        });
+        proc.stdin.on("error", function (err) {
+            // Ignore input if stream is already closed
             return;
-        }
+        });
     }
 }


### PR DESCRIPTION
Fix for issue #2 . The current try-catch block doesn't work because the error is emitted on the stream object which subsequently resets the connection causing the server to crash. The correct way to handle this is to listen for errors on the stream object while writing to STDIN.